### PR TITLE
Add feature which executes additional commands when switching

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -24,3 +24,9 @@ displays:
     feature: 0x60
     host: 0x04
     guest: 0x03
+commands:
+  guest:
+    - echo switch to guest
+  host:
+    - echo switch to host
+


### PR DESCRIPTION
New section "commands" is added to the configuration
List of commands for "guest" and "host" can be set.

Example:

commands:
  guest:
    - echo switch to guest
  host:
    - echo switch to host

edit:

This can be useful when you want to change the screen setup via `xrandr` or similiar.