### PR TITLE
Add configuration parsing for IPv6 addresses

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -2,6 +2,7 @@ libvirt:
   uri: "qemu:///system"
   domain: "nt10"
 http:
+  ipversion: 4
   address: "192.168.100.1:5001"
   security:
     enabled: true

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -2,7 +2,6 @@ libvirt:
   uri: "qemu:///system"
   domain: "nt10"
 http:
-  ipversion: 4
   address: "192.168.100.1:5001"
   security:
     enabled: true

--- a/virtkvm/__init__.py
+++ b/virtkvm/__init__.py
@@ -20,7 +20,11 @@ class LibvirtConfig:
 
 class HTTPConfig:
     def __init__(self, data: dict):
-        addr = data["address"].split(":")
+        ipv = int(data.get("ipversion", 4))
+        if ipv == 6:
+            addr = data["address"][1:].split(']:')
+        else:
+            addr = data["address"].split(":")
         self.host: str = addr[0]
         self.port: int = int(addr[1])
         self._security = data["security"]

--- a/virtkvm/__init__.py
+++ b/virtkvm/__init__.py
@@ -20,12 +20,8 @@ class LibvirtConfig:
 
 class HTTPConfig:
     def __init__(self, data: dict):
-        ipv = int(data.get("ipversion", 4))
-        if ipv == 6:
-            addr = data["address"][1:].split(']:')
-        else:
-            addr = data["address"].split(":")
-        self.host: str = addr[0]
+        addr = data["address"].rsplit(':', maxsplit=1)
+        self.host: str = addr[0].strip('[]')
         self.port: int = int(addr[1])
         self._security = data["security"]
 


### PR DESCRIPTION
Uses standard format for IPv6: [ipv6]:port
Adds ipversion option [4|6]
Defaults to IPv4 if option is bad or not found (due to if/else)
Adds ipversion option to example configuration