### PR TITLE
Added some quality of life features

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,3 +1,6 @@
+kvm:
+  usesudo: false
+  checkguest: true
 libvirt:
   uri: "qemu:///system"
   domain: "nt10"
@@ -29,4 +32,3 @@ commands:
     - echo switch to guest
   host:
     - echo switch to host
-

--- a/virtkvm/__init__.py
+++ b/virtkvm/__init__.py
@@ -123,7 +123,7 @@ class Switch:
         self.virt = Virt(config.libvirt.uri, config.libvirt.domain)
 
     def _call_dccutil(self, display: dict, ident: int):
-        if(self.config.kvm.usesudo):
+        if self.config.kvm.usesudo:
             return subprocess.call([
                 "sudo",
                 "ddcutil",


### PR DESCRIPTION
I've added two features that I found very useful in my setup.
First one is to use sudo for ddcutil - I don't feel comfortable just giving rw permissions to everything to just write to i2c bus, so a good solution is to use sudo just for ddcutil. By adding
`%wheel ALL=(ALL) NOPASSWD: /usr/bin/ddcutil`
to the sudoers file you can make sure that it can be called without any password prompt. This presents some security implications on its own, but I think it's nice to have as a workaround.

The second feature is to check if the guest is running before switching the kvm. Sometimes I forget to start the guest, and having to manually switch back the monitor just to do it can be somewhat frustrating.